### PR TITLE
fix: add check-version-tag build guard to make build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 * MINOR version when you add functionality in a backwards-compatible manner, and
 * PATCH version when you make backwards-compatible bug fixes.
 
+## Unreleased
+
+- fix: `make build` refuses to stamp a version onto a tree that is not that version's tag (`check-version-tag`, escape hatch `ALLOW_UNTAGGED_BUILD=1`). `VERSION` defaults to the newest tag repo-wide, so an operator-run build from an untagged or older tree silently republishes under the newest tag. The guard compares `git describe --exact-match HEAD` against `$(VERSION)` and exits non-zero on mismatch.
+
 ## 1.4.1
 
 - Remove unused DOCKER_REGISTRY and BRANCH variables

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,24 @@ endif
 
 default: build
 
+.PHONY: check-version-tag
+check-version-tag:
+	@if [ -n "$(ALLOW_UNTAGGED_BUILD)" ]; then \
+		echo "ALLOW_UNTAGGED_BUILD set — skipping version/tag check"; \
+	else \
+		head_tag=$$(git describe --tags --exact-match HEAD 2>/dev/null); \
+		if [ "$$head_tag" != "$(VERSION)" ]; then \
+			echo "ERROR: refusing to build $(VERSION) from this tree." >&2; \
+			echo "  HEAD is at tag: $${head_tag:-<untagged>}" >&2; \
+			echo "  building as:    $(VERSION)" >&2; \
+			echo "  An image stamped vX.Y.Z must be built from the vX.Y.Z tag." >&2; \
+			echo "  Fix: git checkout $(VERSION)   (or set ALLOW_UNTAGGED_BUILD=1 for a scratch build)" >&2; \
+			exit 1; \
+		fi; \
+	fi
+
 .PHONY: build
-build:
+build: check-version-tag
 	DOCKER_BUILDKIT=1 \
 	docker build \
 	--no-cache \


### PR DESCRIPTION
Refuse to stamp a version onto a tree that is not that version's tag. VERSION defaults to the newest tag repo-wide, so an operator-run build from an untagged/older tree silently republishes under the newest tag. The guard compares `git describe --exact-match HEAD` against $(VERSION) and exits non-zero on mismatch. ALLOW_UNTAGGED_BUILD=1 is the documented escape hatch for scratch builds.